### PR TITLE
fix healthcheck for flask

### DIFF
--- a/samples/flask/compose.yaml
+++ b/samples/flask/compose.yaml
@@ -14,4 +14,4 @@ services:
         target: 5000
         published: 5000
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/"]
+      test: ["CMD", "python3", "-c", "import sys, urllib.request; urllib.request.urlopen(sys.argv[1]).read()", "http://localhost:5000/"]


### PR DESCRIPTION
This fixes the daily CI timeout.

To do HTTP healthchecks with Python is not easy, because we need to be able to extract a URL from the Compose healthcheck for the target group, so you need to make sure the URL appears separately on the command line:
```
python3 -c 'import sys, urllib.request;urllib.request.urlopen(sys.argv[1]).read()' http://localhost:333/
```
## Samples Checklist
✅ All good!