### PR TITLE
Update CSRF to allow all defang.dev domain

### DIFF
--- a/samples/django-postgres/app/crm_platform/settings.py
+++ b/samples/django-postgres/app/crm_platform/settings.py
@@ -29,7 +29,7 @@ DEBUG = True
 ALLOWED_HOSTS = ['*']
 
 CSRF_TRUSTED_ORIGINS = [
-    'https://*.prod1.defang.dev',
+    'https://*.defang.dev',
     'http://localhost:8000',
 ]
 

--- a/samples/django/app/defang_sample/settings.py
+++ b/samples/django/app/defang_sample/settings.py
@@ -131,7 +131,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # CSRF
 CSRF_TRUSTED_ORIGINS = [
-    'https://*.prod1.defang.dev'
+    'https://*.defang.dev'
 ]
 
 if DEBUG:


### PR DESCRIPTION
Current *.prod1.defang.app would result in CSRF error when deployed to a different shard like prod1a.defang.app
## Samples Checklist
✅ All good!