### PR TITLE
add jinja2 to fastapi sample dependencies

### DIFF
--- a/samples/fastapi/fastapi/requirements.txt
+++ b/samples/fastapi/fastapi/requirements.txt
@@ -1,3 +1,4 @@
 uwsgi
 fastapi
 uvicorn
+jinja2


### PR DESCRIPTION
This sample fails to deploy
```
2024-09-19T22:29:20.622457Z fastapi ip-10-0-69-129   File "/app/main.py", line 8, in <module>
2024-09-19T22:29:20.622585Z fastapi ip-10-0-69-129     templates = Jinja2Templates(directory="templates")
2024-09-19T22:29:20.622675Z fastapi ip-10-0-69-129                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-09-19T22:29:20.623010Z fastapi ip-10-0-69-129   File "/usr/local/lib/python3.11/site-packages/starlette/templating.py", line 96, in __init__
2024-09-19T22:29:20.623266Z fastapi ip-10-0-69-129     assert jinja2 is not None, "jinja2 must be installed to use Jinja2Templates"
2024-09-19T22:29:20.623386Z fastapi ip-10-0-69-129            ^^^^^^^^^^^^^^^^^^
2024-09-19T22:29:20.623436Z fastapi ip-10-0-69-129 AssertionError: jinja2 must be installed to use Jinja2Templates
 - service fastapi with state ( DEPLOYMENT_FAILED ) and status: TASK_FAILED EssentialContainerExited
 - Tail failed with tail --since 2024-09-19T22:29:20.623436238Z --etag grrxefpydipi --verbose
 ! deployment failed for service "fastapi"
```
## Samples Checklist
✅ All good!