### PR TITLE
consistenly clean up apt artifacts after apt-get install in slim images

### DIFF
--- a/samples/django-postgres/app/Dockerfile
+++ b/samples/django-postgres/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+  && apt-get install -y curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/samples/django/app/Dockerfile
+++ b/samples/django/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+  && apt-get install -y curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/samples/fastapi-postgres/fastapi/Dockerfile
+++ b/samples/fastapi-postgres/fastapi/Dockerfile
@@ -5,11 +5,12 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/fastapi/fastapi/Dockerfile
+++ b/samples/fastapi/fastapi/Dockerfile
@@ -5,11 +5,12 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/flask/flask/Dockerfile
+++ b/samples/flask/flask/Dockerfile
@@ -5,10 +5,11 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required packages
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y --no-install-recommends \
       build-essential \
       python3-dev \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Copy the current directory contents into the container at /app

--- a/samples/javalin/.devcontainer/Dockerfile
+++ b/samples/javalin/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/java:11-bookworm
 
 # Install Maven
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends maven
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends maven \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/samples/javalin/app/Dockerfile
+++ b/samples/javalin/app/Dockerfile
@@ -15,7 +15,10 @@ RUN mvn clean package
 # Stage 2: Create the runtime image
 FROM openjdk:17-jdk-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory
 WORKDIR /app

--- a/samples/langchain/app/Dockerfile
+++ b/samples/langchain/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container
 WORKDIR /app

--- a/samples/nextjs-postgres/app/Dockerfile
+++ b/samples/nextjs-postgres/app/Dockerfile
@@ -25,7 +25,10 @@ FROM node:20-bookworm-slim
 WORKDIR /app
 
 # Install curl
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Copy only the necessary files from the build stage
 COPY --from=builder /app/package*.json ./

--- a/samples/nodejs-chatroom/app/Dockerfile
+++ b/samples/nodejs-chatroom/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-express/app/Dockerfile
+++ b/samples/nodejs-express/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-form/app/Dockerfile
+++ b/samples/nodejs-form/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-http/app/Dockerfile
+++ b/samples/nodejs-http/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-openai/app/Dockerfile
+++ b/samples/nodejs-openai/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-rest-api/app/Dockerfile
+++ b/samples/nodejs-rest-api/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/nodejs-s3/app/Dockerfile
+++ b/samples/nodejs-s3/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory to /app
 WORKDIR /app

--- a/samples/phoenix-postgres/server/Dockerfile
+++ b/samples/phoenix-postgres/server/Dockerfile
@@ -21,8 +21,10 @@ ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 FROM ${BUILDER_IMAGE} as builder
 
 # install build dependencies
-RUN apt-get update -y && apt-get install -y build-essential git \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+RUN apt-get update -qq \
+    && apt-get install -y build-essential git \
+    && apt-get clean \
+    && rm -f /var/lib/apt/lists/*
 
 # prepare build dir
 WORKDIR /app
@@ -67,9 +69,10 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && \
+RUN apt-get update && \
   apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
-  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+  && apt-get clean \
+  && rm -f /var/lib/apt/lists/*
 
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen

--- a/samples/phoenix-postgres/server/dev.Dockerfile
+++ b/samples/phoenix-postgres/server/dev.Dockerfile
@@ -2,7 +2,10 @@
 FROM hexpm/elixir:1.16.2-erlang-24.0.6-debian-buster-20240513-slim
 
 # Install build dependencies
-RUN apt-get update -y && apt-get install -y build-essential git inotify-tools
+RUN apt-get update -qq \
+      && apt-get install -y build-essential curl inotify-tools \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Prepare build dir
 WORKDIR /app

--- a/samples/python-form/app/Dockerfile
+++ b/samples/python-form/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/python-implicit-gpu/app/Dockerfile
+++ b/samples/python-implicit-gpu/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/python-minimal/app/Dockerfile
+++ b/samples/python-minimal/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/python-openai/app/Dockerfile
+++ b/samples/python-openai/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/python-rest-api/app/Dockerfile
+++ b/samples/python-rest-api/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/python-s3/app/Dockerfile
+++ b/samples/python-s3/app/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install required C++11 libraries and ca-certificates
-RUN apt-get update \
+RUN apt-get update -qq \
       && apt-get install -y \
       build-essential \
       python3-dev \
       ca-certificates \
       curl \
+      && apt-get clean \
       && rm -rf /var/lib/apt/lists/*
 
 # Install any needed packages specified in requirements.txt

--- a/samples/rails/.devcontainer/Dockerfile
+++ b/samples/rails/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
 ARG RUBY_VERSION=3.3.4
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
-RUN apt-get update && apt-get install -y postgresql-client libpq-dev
+RUN apt-get update -qq \
+      && apt-get install -y postgresql-client libpq-dev \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*

--- a/samples/rails/app/Dockerfile
+++ b/samples/rails/app/Dockerfile
@@ -17,8 +17,10 @@ ENV RAILS_ENV="production" \
 FROM base as build
 
 # Install packages needed to build gems
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set bundler config to force ruby platform
 RUN bundle config set force_ruby_platform true
@@ -45,7 +47,8 @@ FROM base
 # Install packages needed for deployment
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl libvips libpq-dev && \
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle

--- a/samples/rails/app/Dockerfile.dev
+++ b/samples/rails/app/Dockerfile.dev
@@ -11,8 +11,10 @@ ENV RAILS_ENV="development" \
     PORT=3000
 
 # Install packages needed to build gems
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev postgresql-client
+RUN apt-get update -qq \
+    && apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set bundler config to force ruby platform
 RUN bundle config set force_ruby_platform true

--- a/samples/sailsjs-postgres/app/Dockerfile
+++ b/samples/sailsjs-postgres/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/samples/svelte-mysql/app/Dockerfile
+++ b/samples/svelte-mysql/app/Dockerfile
@@ -13,7 +13,10 @@ RUN npm install --legacy-peer-deps && npm run build
 # Stage 2: Build Node.js backend
 FROM node:20-bookworm-slim as backend
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/samples/sveltekit-mongodb/app/Dockerfile
+++ b/samples/sveltekit-mongodb/app/Dockerfile
@@ -1,7 +1,10 @@
 # Use the slim version of Node.js v20 on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update -qq \
+      && apt-get install -y curl \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
Working through each sample and trying to consistenyl apply [best practices when building](https://docs.docker.com/build/building/best-practices/) by cleaning up after apt.

Note that docker docs suggest that we don't need to run `apt-get clean`, but we don't actually use docker, so we will keep that line in our dockerfiles explicitly.
## Samples Checklist
✅ All good!