### PR TITLE
Fix golang samples: there are no golang-slim images

### DIFF
--- a/samples/golang-http-form/app/Dockerfile
+++ b/samples/golang-http-form/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-http/app/Dockerfile
+++ b/samples/golang-http/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-alpine as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM alpine:latest
-
-RUN apk --no-cache add ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-http/compose.yaml
+++ b/samples/golang-http/compose.yaml
@@ -12,4 +12,4 @@ services:
         reservations:
           memory: 50M
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]

--- a/samples/golang-mongodb-atlas/app/Dockerfile
+++ b/samples/golang-mongodb-atlas/app/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Go image.
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o taskmanager .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-openai/app/Dockerfile
+++ b/samples/golang-openai/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-rest-api/app/Dockerfile
+++ b/samples/golang-rest-api/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-s3/app/Dockerfile
+++ b/samples/golang-s3/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 

--- a/samples/golang-slackbot/app/Dockerfile
+++ b/samples/golang-slackbot/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Go runtime as a parent image
-FROM golang:1.20-slim as builder
+FROM golang:1.20 as builder
 
 # Set the working directory in the builder container
 WORKDIR /src
@@ -17,9 +17,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 # Start a new stage from scratch
-FROM golang:1.20-slim
-
-RUN apt update && apt install -y curl ca-certificates
+FROM golang:1.20
 
 WORKDIR /root/
 


### PR DESCRIPTION
Updating golang samples to avoid bad reference to `golang-slim` images. These images do not exist.

We still don't want to use alpine, so we are using the full sized images. These images already have `ca-certificates` and `curl` installed, so we don't need to add them as a separate step.
## Samples Checklist
✅ All good!