### PR TITLE
Fixed html-css-js readme

### DIFF
--- a/samples/html-css-js/README.md
+++ b/samples/html-css-js/README.md
@@ -15,7 +15,7 @@ This sample shows how to get a static HTML + CSS + JavaScript website up and run
 To run the application locally, you can use the following command:
 
 ```bash
-docker compose up
+docker compose up --build
 ```
 
 

--- a/samples/html-css-js/README.md
+++ b/samples/html-css-js/README.md
@@ -1,6 +1,6 @@
 # HTML & CSS & JavaScript
 
-[1-click deploy](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-html-css-js-template%26template_owner%3DDefangSamples)
+[![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-html-css-javascript-template%26template_owner%3DDefangSamples)
 
 This sample shows how to get a static HTML + CSS + JavaScript website up and running with Defang.
 

--- a/samples/html-css-js/README.md
+++ b/samples/html-css-js/README.md
@@ -18,12 +18,28 @@ To run the application locally, you can use the following command:
 docker compose up
 ```
 
-## Deploying
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI.
-3. Your app will be running within a few minutes.
+## Deployment
 
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 ---
 
 Title: HTML & CSS & JavaScript


### PR DESCRIPTION
1-click deploy button in readme did not show up properly due to a typo
## Samples Checklist
✅ All good!