### PR TITLE
Added larger code block in starter sample readme

### DIFF
--- a/starter-sample/README.md
+++ b/starter-sample/README.md
@@ -24,7 +24,7 @@ docker compose up --build
 
 For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration). Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
 
-### `API_KEY` #REMOVE_ME_AFTER_EDITING
+### `API_KEY` #REMOVE_ME_AFTER_EDITING 
 An explanation of what the env var (`API_KEY`) is, etc.
 
 ## Deployment

--- a/starter-sample/README.md
+++ b/starter-sample/README.md
@@ -34,7 +34,10 @@ An explanation of what the env var (`API_KEY`) is, etc.
 
 ### Defang Playground
 
-Deploy your application to the defang playground by opening up your terminal and typing `defang up`.
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
 
 ### BYOC (AWS)
 

--- a/starter-sample/README.md
+++ b/starter-sample/README.md
@@ -44,7 +44,10 @@ defang compose up
 If you want to deploy to your own cloud account, you can use Defang BYOC:
 
 1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
-2. Run `defang --provider=aws up` in a terminal that has access to your AWS environment variables.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 


### PR DESCRIPTION
Made `defang compose up` instead of `defang up`, put into its own larger code block for clarity. 
Also added it for byoc.