### PR TITLE
Uppercase HTTP and more fixes in readme

### DIFF
--- a/samples/fastapi/README.md
+++ b/samples/fastapi/README.md
@@ -29,7 +29,7 @@ That will start your FastAPI app on `http://localhost:8000` with hot reloading e
 
 Title: FastAPI
 
-Short Description: A sample project demonstrating how to deploy FastAPI with Defang
+Short Description: A sample project demonstrating how to deploy FastAPI with Defang.
 
 Tags: FastAPI, OpenAPI, Python
 

--- a/samples/golang-http-form/README.md
+++ b/samples/golang-http-form/README.md
@@ -27,10 +27,10 @@ This Go application demonstrates a simple form submission using the standard net
 
 ---
 
-Title: Go http Form
+Title: Go HTTP Form
 
 Short Description: A simple Go application that demonstrates form submission using the net/http library.
 
-Tags: Go, http
+Tags: Go, HTTP
 
 Languages: golang

--- a/samples/golang-http/README.md
+++ b/samples/golang-http/README.md
@@ -6,10 +6,10 @@ A very simple example of a Go service that listens on a port and returns informa
 
 ---
 
-Title: Go http Server
+Title: Go HTTP Server
 
 Short Description: A simple Go application that echoes back the request.
 
-Tags: Go, http
+Tags: Go, HTTP
 
 Languages: golang

--- a/samples/nodejs-express/README.md
+++ b/samples/nodejs-express/README.md
@@ -24,8 +24,8 @@ This Node.js application, built with Express.js, is designed to inspect and disp
 
 Title: Node.js & Express
 
-Short Description: A Node.js application that inspects and displays detailed information about incoming http requests.
+Short Description: A Node.js application that inspects and displays detailed information about incoming HTTP requests.
 
-Tags: Node.js, Express, http, Request, Inspector, JavaScript
+Tags: Node.js, Express, HTTP, Request, Inspector, JavaScript
 
 Languages: nodejs

--- a/samples/nodejs-form/README.md
+++ b/samples/nodejs-form/README.md
@@ -26,6 +26,6 @@ Title: Node.js Express Form
 
 Short Description: A Node.js application that handles form submissions using the Express framework.
 
-Tags: Node.js, Express, http, JavaScript
+Tags: Node.js, Express, HTTP, JavaScript
 
 Languages: nodejs

--- a/samples/nodejs-http/README.md
+++ b/samples/nodejs-http/README.md
@@ -20,8 +20,8 @@ defang compose up
 
 Title: Node.js HTTP Server
 
-Short Description: A simple Node.js application that creates an http server.
+Short Description: A simple Node.js application that creates an HTTP server.
 
-Tags: Node.js, http, Server
+Tags: Node.js, HTTP, Server
 
 Languages: nodejs

--- a/samples/pulumi/README.md
+++ b/samples/pulumi/README.md
@@ -40,6 +40,6 @@ Title: Pulumi
 
 Short Description: A basic Pulumi example.
 
-Tags: Pulumi, Node.js, http, Server, TypeScript
+Tags: Pulumi, Node.js, HTTP, Server, TypeScript
 
 Languages: nodejs

--- a/samples/python-minimal/README.md
+++ b/samples/python-minimal/README.md
@@ -29,8 +29,8 @@ This Flask application is designed to inspect and return detailed information ab
 
 Title: Flask
 
-Short Description: A Flask application that inspects and returns detailed information about http requests.
+Short Description: A Flask application that inspects and returns detailed information about HTTP requests.
 
-Tags: Flask, http, Python
+Tags: Flask, HTTP, Python
 
 Languages: python


### PR DESCRIPTION
- Uppercase HTTP for tags/short descriptions for samples
- Added a period at the end of short description for FastAPI sample
## Samples Checklist
✅ All good!