### PR TITLE
uppercase http in go-rest-api sample

### DIFF
--- a/samples/golang-rest-api/README.md
+++ b/samples/golang-rest-api/README.md
@@ -10,6 +10,6 @@ Title: Go & REST API
 
 Short Description: A simple Go application that fetches fiscal data from an API.
 
-Tags: Go, http, Fiscal Data, REST API
+Tags: Go, HTTP, Fiscal Data, REST API
 
 Languages: golang


### PR DESCRIPTION
- made HTTP uppercase in go-rest-api sample to keep it consistent with #230
## Samples Checklist
✅ All good!