### PR TITLE
Updates to fastapi-postgres + various readmes

### DIFF
--- a/samples/angular-express/README.md
+++ b/samples/angular-express/README.md
@@ -2,36 +2,58 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-angular-express-template%26template_owner%3DDefangSamples)
 
-This project demonstrates both client-side component rendering and hydration with Angular, as well as server-side rendering with Node.js and Socket.IO for real-time communication. It also includes Docker configurations for easy deployment.
+This project demonstrates both client-side component rendering and hydration with Angular, as well as server-side rendering with Node.js and Socket.IO for real-time communication. 
 
-## NOTE
-
-This sample showcases how you could deploy a full-stack application with Angular and Node.js using Defang. The Docker setup ensures the app can be easily built and deployed.
-
-## Essential Setup Files
-
-1. Download [Defang CLI](https://github.com/defang-io/defang)
-2. (Optional) If you are using [Defang BYOC](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) authenticated with your AWS account
-3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+It showcases how you could deploy a full-stack application with Angular and Node.js using Defang. The Docker setup ensures the app can be easily built and deployed.
 
 ## Prerequisites
 
-1. Download [Defang CLI](https://github.com/defang-io/defang)
-2. (Optional) If you are using [Defang BYOC](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) make sure you have properly authenticated your AWS account
-3. [Node.js](https://nodejs.org/en/download/package-manager/)
-4. [Angular CLI](https://angular.io/cli)
-
-## A Step-by-Step Guide for deployment
-
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Your app should be up and running with Defang in minutes!
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+4. Install [Node.js](https://nodejs.org/en/download/package-manager/)
+5. Install [Angular CLI](https://angular.io/cli)
 
 ## Development
+For development, we use two local containers, one for the frontend Angular service and one for the backend service in Express. It also uses Caddy as a web server for serving static files. 
 
-For development, we use two local containers, one for the frontend Angular service and one for the backend service in Express. It also uses Caddy as a web server for serving static files. To run the sample locally after cloning the repository, you can run on Docker by doing:
+To run the application locally, you can use the following command:
 
-1. `docker compose -f compose.dev.yaml up --build`
+```bash
+docker compose -f compose.dev.yaml up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/angular-express/README.md
+++ b/samples/angular-express/README.md
@@ -2,9 +2,7 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-angular-express-template%26template_owner%3DDefangSamples)
 
-This project demonstrates both client-side component rendering and hydration with Angular, as well as server-side rendering with Node.js and Socket.IO for real-time communication. 
-
-It showcases how you could deploy a full-stack application with Angular and Node.js using Defang. The Docker setup ensures the app can be easily built and deployed.
+This sample demonstrates how to deploy a full-stack Angular and Node.js application with Defang. It uses Socket.IO for real-time communication. The Docker setup ensures the app can be easily built and deployed.
 
 ## Prerequisites
 

--- a/samples/bullmq-bullboard-redis/README.md
+++ b/samples/bullmq-bullboard-redis/README.md
@@ -4,27 +4,64 @@
 
 This sample project demonstrates how to deploy a BullMQ message queue on top of managed Redis with a queue processor and a dashboard to monitor the queue.
 
-Once your app is up and running you can go to the `/board` route for the `board` service to see the Bull Board dashboard and use the username `admin` and the password you set to log in (see [Deploying](#deploying)).
+Once your app is up and running you can go to the `/board` route for the `board` service to see the Bull Board dashboard and use the username `admin` and the board password you set to log in (see [Configuration](#configuration)).
 
-To add a job to the queue, you can go to the `/add` route of the `api` service. This will use some default values so you can test things out. You can also see an example of a post request in the [sample http request](./api/add.test.http) file.
+To add a job to the queue, you can go to the `/add` route of the `api` service. This will use some default values so you can test things out. You can also see an example of a post request in the [sample HTTP request](./api/add.test.http) file.
 
 The `worker` service is the queue processor that will process the jobs added to the queue. You can see in the `compose.yaml` file that the `worker` service is set to scale to 2 instances. This means that there will be 2 workers processing jobs from the queue. You can set this to your desired number of workers, but we wanted to show how you can increase the number of workers to handle more jobs.
 
 ## Prerequisites
 
-1. Download <a href="https://github.com/defang-io/defang">Defang CLI</a>
-2. (optional) If you are using <a href="https://docs.defang.io/docs/concepts/defang-byoc">Defang BYOC</a>, make sure you have properly <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html">authenticated your AWS account</a>.
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## Deploying
+## Development
 
-1. Open the terminal and type `defang login`
-2. Run `defang config set BOARD_PASSWORD` to set the password for the BullBoard dashboard.
-3. Type `defang compose up` in the CLI.
-4. Your app will be running within a few minutes.
+To run the application locally, you can use the following command:
 
-## Local Development
+```bash
+docker compose -f compose.dev.yaml up --build
+```
 
-1. Run `docker compose -f compose.dev.yaml up --build`
+## Configuration
+
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `BOARD_PASSWORD`
+Set a board password and use together with the board username `admin` when signing in.
+```bash
+defang config set BOARD_PASSWORD
+```
+
+### `QUEUE`
+```bash
+defang config set QUEUE
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/bullmq-bullboard-redis/README.md
+++ b/samples/bullmq-bullboard-redis/README.md
@@ -2,7 +2,7 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-bullmq-bullboard-redis-template%26template_owner%3DDefangSamples)
 
-This sample project demonstrates how to deploy a BullMQ message queue on top of managed Redis with a queue processor and a dashboard to monitor the queue.
+This sample demonstrates how to deploy a BullMQ message queue on top of managed Redis with a queue processor and a dashboard to monitor the queue.
 
 Once your app is up and running you can go to the `/board` route for the `board` service to see the Bull Board dashboard and use the username `admin` and the board password you set to log in (see [Configuration](#configuration)).
 

--- a/samples/bullmq-bullboard-redis/api/Dockerfile
+++ b/samples/bullmq-bullboard-redis/api/Dockerfile
@@ -1,6 +1,11 @@
 # Use the slim version of Node.js v20 on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
+# Install tools for healthcheck
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory
 WORKDIR /app
 

--- a/samples/bullmq-bullboard-redis/board/Dockerfile
+++ b/samples/bullmq-bullboard-redis/board/Dockerfile
@@ -1,6 +1,11 @@
 # Use the slim version of Node.js on Debian Bookworm as the base image
 FROM node:20-bookworm-slim
 
+# Install tools for healthcheck
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory
 WORKDIR /app
 

--- a/samples/bullmq-bullboard-redis/compose.yaml
+++ b/samples/bullmq-bullboard-redis/compose.yaml
@@ -12,6 +12,8 @@ services:
       - REDIS=redis://redisx:6379
       - BOARD_PASSWORD
       - QUEUE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "127.0.0.1:3000"]
     depends_on:
       - redisx
     #deploy:
@@ -31,6 +33,8 @@ services:
     environment:
       - REDIS=redis://redisx:6379
       - QUEUE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "127.0.0.1:3001"]
     depends_on:
       - redisx
     #deploy:
@@ -48,8 +52,6 @@ services:
     environment:
       - REDIS=redis://redisx:6379
       - QUEUE
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "127.0.0.1:3000"]
     depends_on:
       - redisx
     #deploy:

--- a/samples/csharp-dotnet/README.md
+++ b/samples/csharp-dotnet/README.md
@@ -2,41 +2,63 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-csharp-dotnet-template%26template_owner%3DDefangSamples)
 
-This project is a simple task manager application using ASP.NET Core. We show case how to deploy it to both Defang and Docker for both prod and dev environments.
+This sample project is a simple task manager application using ASP.NET Core for the backend and JavaScript for client-side component rendering. 
 
-## NOTE
-
-This sample showcases how you could deploy a full-stack application with ASP.NET Core and JavaScript using Defang. The Docker setup ensures the app can be easily built and tested during development.
-
-## Essential Setup Files
-
-1. Download [Defang CLI](https://github.com/defang-io/defang)
-2. (Optional) If you are using [Defang BYOC](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) authenticated with your AWS account
-3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+It showcases how you could deploy a full-stack application with ASP.NET Core and JavaScript using Defang. The Docker setup ensures the app can be easily built and tested during development.
 
 ## Prerequisites
 
-1. Download [Defang CLI](https://github.com/defang-io/defang)
-2. (Optional) If you are using [Defang BYOC](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) make sure you have properly authenticated your AWS account
-3. [ASP.NET Core](https://dotnet.microsoft.com/download/dotnet-core)
-
-## A Step-by-Step Guide for deployment
-
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Your app should be up and running with Defang in minutes!
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+4. Install [ASP.NET Core](https://dotnet.microsoft.com/download/dotnet-core)
 
 ## Development
 
-For development, we use two local containers, one for the frontend service and one for the backend service in ASP.NET Core. It also uses Caddy as a web server for serving static files. To run the sample locally after cloning the repository, you can run on Docker by doing:
+For development, we use two local containers, one for the frontend service and one for the backend service in ASP.NET Core. It also uses Caddy as a web server for serving static files.
 
-`docker compose -f compose.dev.yaml up --build`
+To run the application locally, you can use the following command:
+
+```bash
+docker compose -f compose.dev.yaml up --build
+```
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 
 Title: C# & ASP.NET Core
 
-Short Description: A task manager using ASP.NET Core containerized with Docker.
+Short Description: A simple task manager application using C# and ASP.NET Core.
 
 Tags: ASP.NET Core, JavaScript, C#
 

--- a/samples/django-postgres/README.md
+++ b/samples/django-postgres/README.md
@@ -4,27 +4,55 @@
 
 This template is a customer relationship management list project developed using Python Django framework, offering a starting point to help you quickly build your customer management system. We use PostgreSQL as the database. We have prepared all the essential files for deployment. By spending less than 10 minutes setting up the environment, as detailed in the prerequisites, and executing the commands in our step-by-step guide, your website will be ready to go live to the world!
 
-## NOTE
+> [!NOTE]
+This sample showcases how you could deploy a full-stack application with Defang and Django. However, it deploys Postgres as a Defang service. Defang [services](https://12factor.net/processes) are ephemeral and should not be used to run stateful workloads in production as they will be reset on every deployment. For production use cases you should use a managed database like RDS, Aiven, or others. If you stick to Django's default SQLite database, your stored data will be lost on every deployment, and in some other situations. In the future, Defang will help you provision and connect to managed databases.
 
-This sample showcases how you could deploy a full-stack application with Defang and Django. However, it deploys postgres as a defang service. Defang [services](https://12factor.net/processes) are ephemeral and should not be used to run stateful workloads in production as they will be reset on every deployment. For production use cases you should use a managed database like RDS, Aiven, or others. If you stick to Rail's default SQLite database, your stored data will be lost on every deployment, and in some other situations. In the future, Defang will help you provision and connect to managed databases.
-
-## Essential Setup Files
-
-1. A [Dockerfile](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) to describe the basic image of your applications.
-2. A [docker-compose file](https://docs.defang.io/docs/concepts/compose) to define and run multi-container Docker applications.
-3. A [.dockerignore](https://docs.docker.com/build/building/context/#dockerignore-files) file to comply with the size limit (10MB).
-
-## Prerequisite
+## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc), make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
-   Plus, make sure that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## A Step-by-Step Guide for Deployment
+## Development
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Now your application will be launched
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `POSTGRES_PASSWORD` 
+```bash
+defang config set POSTGRES_PASSWORD
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/django/README.md
+++ b/samples/django/README.md
@@ -2,34 +2,58 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-django-template%26template_owner%3DDefangSamples)
 
-This is a simple example of how to run Django on Defang. It is a simple Todo app that uses SQLite as the database.
-
-### NOTE
-
-This sample is a simple Django app that uses SQLite as the database, which will be reset every time you deploy. **It is not production-ready**. For production use cases, you should check out the Django + Postgres sample.
+This sample is a simple Django to-do app that uses SQLite as the database, which will be reset every time you deploy. **It is not production-ready**. For production use cases, you should check out the Django + Postgres sample.
 
 The app includes a management command which is run on startup to create a superuser with the username `admin` and password `admin`. This means you can login to the admin interface at `/admin/` and see the Django admin interface without any additional steps. The `example_app` is already registered and the `Todo` model is already set up to be managed in the admin interface.
 
 The Dockerfile and compose files are already set up for you and are ready to be deployed. Serving is done using [Gunicorn](https://gunicorn.org/) and uses [WhiteNoise](https://whitenoise.readthedocs.io/en/latest/) for static files. The `CSRF_TRUSTED_ORIGINS` setting is configured to allow the app to run on a `defang.dev` subdomain.
 
-## Essential Setup Files
-
-1. A [Dockerfile](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) to describe the basic image of your applications.
-2. A [docker-compose file](https://docs.defang.io/docs/concepts/compose) to define and run multi-container Docker applications.
-3. A [.dockerignore](https://docs.docker.com/build/building/context/#dockerignore-files) file to comply with the size limit (10MB).
-
-## Prerequisite
+## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc), make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
-   Plus, make sure that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## A Step-by-Step Guide
+## Development
 
-1. (optional) If you are using Defang BYOC, make sure to update the `CSRF_TRUSTED_ORIGINS` setting in the `settings.py` file to include an appropriate domain.
-2. Open the terminal and type `defang login`
-3. Type `defang compose up` in the CLI
-4. Now your application will be launched
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Make sure to update the `CSRF_TRUSTED_ORIGINS` setting in the `settings.py` file to include an appropriate domain.
+3. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/elysia/README.md
+++ b/samples/elysia/README.md
@@ -7,18 +7,48 @@ A basic [Elysia](https://elysiajs.com/) app running on [Bun](https://bun.sh/) wi
 ## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. (Optional) If you are using [Defang BYOC](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) authenticated with your AWS account
-3. (Optional - for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## Deploying
+## Development
 
-1. Run `defang login` if you are not yet logged in.
-2. Run `defang compose up`.
-3. Your app will be running within a few minutes.
+To run the application locally, you can use the following command:
 
-## Local Development
+```bash
+docker compose -f compose.dev.yaml up --build
+```
 
-1. Run `docker compose -f compose.dev.yaml up --build`
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/fastapi-postgres/README.md
+++ b/samples/fastapi-postgres/README.md
@@ -11,7 +11,7 @@ This sample project demonstrates how to deploy FastAPI with PostgreSQL with Defa
 
 ## Development
 
-To run the development container(s) locally, do:
+To run the application locally, you can use the following command:
 
 ```
 docker compose -f compose.dev.yaml up --build
@@ -27,11 +27,12 @@ POSTGRES_PASSWORD=postgres docker compose up --build
 
 For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
 
-``` 
-defang config create POSTGRES_PASSWORD
-```
-
 > Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `POSTGRES_PASSWORD` 
+``` bash
+defang config set POSTGRES_PASSWORD
+```
 
 ## Deployment
 

--- a/samples/fastapi-postgres/README.md
+++ b/samples/fastapi-postgres/README.md
@@ -11,7 +11,7 @@ This sample project demonstrates how to deploy FastAPI with PostgreSQL with Defa
 
 ## Development
 
-To run the application locally, you can use the following command:
+To run the development container(s) locally, do:
 
 ```
 docker compose -f compose.dev.yaml up --build

--- a/samples/fastapi-postgres/README.md
+++ b/samples/fastapi-postgres/README.md
@@ -13,13 +13,13 @@ This sample project demonstrates how to deploy FastAPI with PostgreSQL with Defa
 
 To run the development container(s) locally, do:
 
-```
+```bash
 docker compose -f compose.dev.yaml up --build
 ```
 
 Or to run the production container(s) locally, do:
 
-```
+```bash
 POSTGRES_PASSWORD=postgres docker compose up --build
 ```
 

--- a/samples/fastapi-postgres/README.md
+++ b/samples/fastapi-postgres/README.md
@@ -9,15 +9,51 @@ This sample project demonstrates how to deploy FastAPI with PostgreSQL with Defa
 1. Download <a href="https://github.com/defang-io/defang">Defang CLI</a>
 2. (optional) If you are using <a href="https://docs.defang.io/docs/concepts/defang-byoc">Defang BYOC</a>, make sure you have properly <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html">authenticated your AWS account</a>.
 
-## Deploying
+## Development
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI.
-3. Your app will be running within a few minutes.
+To run the development container(s) locally, do:
 
-## Local Development
+```
+docker compose -f compose.dev.yaml up --build
+```
 
-1. Run `docker compose -f compose.dev.yaml up --build`
+Or to run the production container(s) locally, do:
+
+```
+POSTGRES_PASSWORD=postgres docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+``` 
+defang config create POSTGRES_PASSWORD
+```
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/fastapi-postgres/compose.dev.yaml
+++ b/samples/fastapi-postgres/compose.dev.yaml
@@ -3,9 +3,6 @@ services:
     extends:
       file: compose.yaml
       service: fastapi
-    restart: unless-stopped
-    ports:
-      - "8000:8000"
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
     volumes:
@@ -15,8 +12,9 @@ services:
     command: fastapi dev main.py --host 0.0.0.0
 
   db:
-    image: postgres:15
-    restart: unless-stopped
+    extends:
+      file: compose.yaml
+      service: db
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/samples/fastapi-postgres/compose.yaml
+++ b/samples/fastapi-postgres/compose.yaml
@@ -7,9 +7,18 @@ services:
     ports:
       - mode: ingress
         target: 8000
+        published: 8000
     environment:
-      - DATABASE_URL
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
     #deploy:
     #  resources:
     #    reservations:
     #      memory: 256M
+
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB=postgres

--- a/samples/fastapi-postgres/fastapi/requirements.txt
+++ b/samples/fastapi-postgres/fastapi/requirements.txt
@@ -1,5 +1,5 @@
 uwsgi
-fastapi
+fastapi[standard]
 uvicorn
 asyncpg
 databases

--- a/samples/fastapi-postgres/fastapi/requirements.txt
+++ b/samples/fastapi-postgres/fastapi/requirements.txt
@@ -4,3 +4,5 @@ uvicorn
 asyncpg
 databases
 python-dotenv
+jinja2
+python-multipart

--- a/samples/fastapi/README.md
+++ b/samples/fastapi/README.md
@@ -6,24 +6,49 @@ This sample project demonstrates how to deploy FastAPI with Defang.
 
 ## Prerequisites
 
-1. Download <a href="https://github.com/defang-io/defang">Defang CLI</a>
-2. (optional) If you are using <a href="https://docs.defang.io/docs/concepts/defang-byoc">Defang BYOC</a>, make sure you have properly <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html">authenticated your AWS account</a>.
-
-## Deploying
-
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI.
-3. Your app will be running within a few minutes.
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
 ## Development
 
-To run your FastAPI app locally, you'll need to have Docker installed on your machine. You can then run:
+To run the application locally, you can use the following command:
 
 ```bash
 docker compose -f compose.yaml -f compose.dev.yaml up --build
 ```
 
-That will start your FastAPI app on `http://localhost:8000` with hot reloading enabled.
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration).
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/feathersjs/README.md
+++ b/samples/feathersjs/README.md
@@ -6,25 +6,51 @@ This sample project demonstrates how to deploy a FeathersJS application on to AW
 
 ## Prerequisites
 
-1. Download [Defang CLI](https://github.com/DefangLabs/defang) (for Defang deployment)
-2. (Optional - for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 3. (Optional - for local development) [Node.js](https://nodejs.org/en/download/)
 
-### Local Development
-
+## Development
 For development, we use Docker to containerize the FeathersJS application. The Docker Compose configuration is defined in the `compose.dev.yaml` file.
 
-To start the development environment, run:
+To run the application locally, you can use the following command:
 
-```sh
+```bash
 docker compose -f compose.dev.yaml up --build
 ```
 
-# Deploying
+## Configuration
 
-1. Open the terminal and type defang login
-2. Type `defang compose up` in the CLI.
-3. Your app will be running within a few minutes.
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/flask/README.md
+++ b/samples/flask/README.md
@@ -2,36 +2,61 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-flask-template%26template_owner%3DDefangSamples)
 
-This is a sample of a basic Flask TODO app. The items are stored in memory and are lost when the server is restarted, but it should give you a basic idea of how to get started with Flask on Defang. Note that alognside your .py file, include a requirements.txt so that the Dockerfile can install the necessary packages with pip.
+This is a basic Flask to-do app that can be deployed with Defang.  Note that alongside your `.py` file, include a `requirements.txt` so that the Dockerfile can install the necessary packages with pip.
 
-### NOTE:
+This project is intended to provide a basic understanding of how to get started with Flask on Defang. The items are stored in memory and are lost when the server is restarted. **It is not intended for production use**. If you need something production ready, you should use a managed database like Postgres or MySQL.
 
-This sample is a simple Flask app that demonstrates how to create a TODO app using Flask. The items are stored in memory and are lost when the server is restarted. This sample is intended to provide a basic understanding of how to get started with Flask on Defang. **it is not intended for production use**. If you need something production ready, you should use a managed database like Postgres or MySQL.
-
-## Essential Setup Files
-
-1. A [Dockerfile](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
-2. A [compose file](https://docs.defang.io/docs/concepts/compose) to define and run multi-container Docker applications (this is how Defang identifies services to be deployed).
-3. A [.dockerignore](https://docs.docker.com/build/building/context/#dockerignore-files) to ignore files that are not needed in the Docker image or will be generated during the build process.
-
-## Prerequisite
+## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc), make sure you have properly [authenticated your AWS account (optional)](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## A Step-by-Step Guide
+## Development
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Your app should be up and running with Defang in minutes!
+To run the application locally, you can use the following command:
 
-## One click deployment
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 
 Title: Flask
 
-Short Description: A basic Flask to do app.
+Short Description: A basic Flask to-do app.
 
 Tags: Flask, Python
 

--- a/samples/golang-http-form/README.md
+++ b/samples/golang-http-form/README.md
@@ -4,26 +4,51 @@
 
 This Go application demonstrates a simple form submission using the standard net/http library. Users can input their first name into a form, and upon submission, they will be greeted personally by the application.
 
-## Features
-
-1. Simple form to submit a user's first name.
-2. Personalized greeting displayed in response to the form submission
-
-## Essential Setup Files
-
-1. A [Dockerfile](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
-2. A [compose file](https://docs.defang.io/docs/concepts/compose) to define and run multi-container Docker applications (this is how Defang identifies services to be deployed). (compose.yaml file)
-
-## Prerequisite
+## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc), make sure you have properly [authenticated your AWS account (optional)](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## A Step-by-Step Guide
+## Development
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Your app should be up and running with Defang in minutes!
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/golang-http/README.md
+++ b/samples/golang-http/README.md
@@ -4,6 +4,52 @@
 
 A very simple example of a Go service that listens on a port and returns information about the request.
 
+## Prerequisites
+
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+
+## Development
+
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
+
 ---
 
 Title: Go HTTP Server

--- a/samples/golang-mongodb-atlas/README.md
+++ b/samples/golang-mongodb-atlas/README.md
@@ -2,36 +2,59 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-mongodb-atlas-template%26template_owner%3DDefangSamples)
 
-## Overview
+This sample is a task manager application that uses Go and MongoDB Atlas, deployed with Defang. 
 
-This sample is is a web-based task manager designed to help users manage their tasks efficiently. It allows users to add, delete, and view tasks in a simple and intuitive interface. This application is ideal for anyone looking to enhance their productivity by keeping track of their daily activities. There is a go.mod file that includes dependencies for the Dockerfile to install
+HTML and JavaScript are used for the frontend to interact with the backend via API calls. There is a `go.mod` file that includes dependencies for the Dockerfile to install.
 
-## Features
+There is a environment variable named `MONGO_URI` for the `MONGODB` connection string. In the `compose.yaml` file, be sure to put your MongoDB URI, i.e.
+   `mongodb+srv://<username>:<pwd>@host`.
 
-Create Tasks: Users can add new tasks with descriptions.
-Delete Tasks: Users can remove tasks when they are completed or no longer needed.
-View Tasks: Users can view a list of their current tasks.
-
-## Technology
-
-Backend: The application is built with Go (Golang), utilizing the powerful net/http standard library for handling HTTP requests and responses.
-Database: MongoDB is used for storing tasks. It is a NoSQL database that offers high performance, high availability, and easy scalability.
-Frontend: Basic HTML and JavaScript are used for the frontend to interact with the backend via API calls.
-Environment: Designed to run in containerized environments using Docker, which ensures consistency across different development and production environments.
-
-## Prerequisite
+## Prerequisites
 
 1. Download [Defang CLI](https://github.com/DefangLabs/defang)
-2. If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc), make sure you have properly [authenticated your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
-   Plus, make sure that you have properly set all environment variables up
-3. There is a environment variable named MONGO_URI for the MONGODB connection string, in the compose file, be sure to put your mongodb URI, i.e.
-   mongodb+srv://<username>:<pwd>@host
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
 
-## A Step-by-Step Guide
+## Development
 
-1. Open the terminal and type `defang login`
-2. Type `defang compose up` in the CLI
-3. Your app should be up and running with Defang in minutes!
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `MONGODB_URI` 
+A URI for MongoDB that should have a format of `mongodb+srv://<username>:<pwd>@host`.
+```bash
+defang config set MONGODB_URI
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/golang-openai/README.md
+++ b/samples/golang-openai/README.md
@@ -1,29 +1,69 @@
 # Golang & OpenAI
 
-[![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-mongodb-atlas-template%26template_owner%3DDefangSamples)
+[![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-openai-template%26template_owner%3DDefangSamples)
 
-## Setup
+This sample demonstrates how to deploy a Go project with OpenAI using Defang.
 
-This sample requires an API key to access the OpenAI API. The name of the config value is referenced in the compose.yaml file.
-To provide a value for it, you can use the Defang CLI like this:
+## Prerequisites
 
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+
+## Development
+
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
 ```
+
+## Configuration
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `OPENAI_KEY` 
+An API key to access the OpenAI API.
+
+```bash
 defang config set --name OPENAI_KEY
 ```
 
-and then enter the value when prompted.
-
 ## Testing
+Below are some useful commands for testing. 
 
-```
+```bash
 echo "Hello" | curl -H "Content-Type: application/text" -d @- https://xxxxxxxx/prompt
 ```
 
-or
+or alternatively,
 
-```
+```bash
 cat prompt.txt | curl -H "Content-Type: application/text" -d @- https://xxxxxxxx/prompt
 ```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/golang-rest-api/README.md
+++ b/samples/golang-rest-api/README.md
@@ -2,7 +2,55 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-rest-api-template%26template_owner%3DDefangSamples)
 
-This is a simple HTTP server written in Go that serves two endpoints: / and /rates. The / endpoint responds with a JSON object containing the status, while the /rates endpoint fetches data from the Fiscal Data Treasury API and returns the response to the client.
+This sample shows a Go HTTP server that uses a REST API to fetch data, deployed using Defang. 
+
+It serves two endpoints: `/` and `/rates`. The `/` endpoint responds with a JSON object containing the status, while the `/rates` endpoint fetches data from the [Fiscal Data Treasury API](https://fiscaldata.treasury.gov/api-documentation/) and returns the response to the client.
+
+## Prerequisites
+
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+
+## Development
+
+To run the application locally, you can use the following command:
+
+```bash
+docker compose up --build
+```
+
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/golang-s3/README.md
+++ b/samples/golang-s3/README.md
@@ -2,23 +2,68 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-s3-template%26template_owner%3DDefangSamples)
 
-## Setup
+This sample shows a simple Go application that uploads and downloads files from AWS S3, deployed with Defang.
 
-This sample requires an API key to access AWS S3. The name of the config value is referenced in the compose.yaml file.
-To provide a value for it, you can use the Defang CLI like this:
+## Prerequisites
+
+1. Download [Defang CLI](https://github.com/DefangLabs/defang)
+2. (Optional) If you are using [Defang BYOC](https://docs.defang.io/docs/concepts/defang-byoc) authenticate with your cloud provider account
+3. (Optional for local development) [Docker CLI](https://docs.docker.com/engine/install/)
+
+## Development
+
+To run the application locally, you can use the following command:
 
 ```bash
+docker compose up --build
+```
+
+## Configuration
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `AWS_ACCESS_KEY` 
+An AWS access key to use S3. 
+```bash
 defang config set --name AWS_ACCESS_KEY
+```
+
+### `AWS_SECRET_KEY`
+An AWS secret key to use S3.
+```bash
 defang config set --name AWS_SECRET_KEY
 ```
 
-and then enter the value when prompted.
-
 ## Testing
+Below is a useful command for testing.
+
 ```bash
 curl -X POST -H 'Content-Type: application/json' -d '{ "first_name" : "jane", "last_name" : "doe" }' https://xxxxxx/upload
 curl https://xxxxxx/download
 ```
+
+## Deployment
+
+> [!NOTE]
+> Download [Defang CLI](https://github.com/DefangLabs/defang)
+
+### Defang Playground
+
+Deploy your application to the Defang Playground by opening up your terminal and typing:
+```bash
+defang compose up
+```
+
+### BYOC (AWS)
+
+If you want to deploy to your own cloud account, you can use Defang BYOC:
+
+1. [Authenticate your AWS account](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html), and check that you have properly set your environment variables like `AWS_PROFILE`, `AWS_REGION`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+2. Run in a terminal that has access to your AWS environment variables:
+    ```bash
+    defang --provider=aws compose up
+    ```
 
 ---
 

--- a/samples/golang-s3/README.md
+++ b/samples/golang-s3/README.md
@@ -7,7 +7,7 @@
 This sample requires an API key to access AWS S3. The name of the config value is referenced in the compose.yaml file.
 To provide a value for it, you can use the Defang CLI like this:
 
-```
+```bash
 defang config set --name AWS_ACCESS_KEY
 defang config set --name AWS_SECRET_KEY
 ```
@@ -15,9 +15,10 @@ defang config set --name AWS_SECRET_KEY
 and then enter the value when prompted.
 
 ## Testing
-
+```bash
 curl -X POST -H 'Content-Type: application/json' -d '{ "first_name" : "jane", "last_name" : "doe" }' https://xxxxxx/upload
 curl https://xxxxxx/download
+```
 
 ---
 

--- a/samples/html-css-js/README.md
+++ b/samples/html-css-js/README.md
@@ -2,7 +2,7 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-html-css-javascript-template%26template_owner%3DDefangSamples)
 
-This sample shows how to get a static HTML + CSS + JavaScript website up and running with Defang.
+This sample shows how to get a static HTML, CSS and JavaScript website up and running with Defang.
 
 ## Prerequisites
 
@@ -18,6 +18,15 @@ To run the application locally, you can use the following command:
 docker compose up --build
 ```
 
+## Configuration
+
+For this sample, you will not need to provide [configuration](https://docs.defang.io/docs/concepts/configuration). 
+
+If you wish to provide configuration, see below for an example of setting a configuration for a value named `API_KEY`.
+
+```bash
+defang config set API_KEY
+```
 
 ## Deployment
 
@@ -44,7 +53,7 @@ If you want to deploy to your own cloud account, you can use Defang BYOC:
 
 Title: HTML & CSS & JavaScript
 
-Short Description: A simple HTML + CSS + JavaScript website running on Defang. 
+Short Description: A simple HTML, CSS and JavaScript website running on Defang. 
 
 Tags: HTML, CSS, JavaScript, Frontend
 

--- a/starter-sample/README.md
+++ b/starter-sample/README.md
@@ -22,10 +22,15 @@ docker compose up --build
 ## Configuration
 #REMOVE_ME_AFTER_EDITING - this section should be removed if there are no configuration values needed. The intro text can probably stay, but the list of configuration values should be updated/removed if there are none.
 
-For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration). Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
 
-### `API_KEY` #REMOVE_ME_AFTER_EDITING 
+> Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
+
+### `API_KEY` #REMOVE_ME_AFTER_EDITING
 An explanation of what the env var (`API_KEY`) is, etc.
+```bash
+defang config set API_KEY
+```
 
 ## Deployment
 


### PR DESCRIPTION
Details:
- Starter sample now includes `defang config set API_KEY` command in its README (see `bullmq-bullboard-redis` README as an example on what it looks like for a list of values) 
- These samples have been updated to match starter sample's README:
   - `bullmq-bullboard-redis`
   - `django-postgres`
   - `fastapi-postgres`
   
 - `fastapi_postgres` has a better `compose.yaml` and `compose.dev.yaml` structure
   
## Samples Checklist
✅ All good!