### PR TITLE
Fix bash shell installation to use eval

### DIFF
--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Checks
         id: checks
         run: |
-          eval "$(curl -Ls https://s.defang.io/install)"
+          eval "$(curl -fsSL https://s.defang.io/install)"
           ./scripts/check-sample-files.sh > checklist.txt
           ./scripts/check-modified-samples.sh > modified.txt
           echo "@@ MODIFIED @@"
@@ -31,7 +31,7 @@ jobs:
       #       once we figure out how to prevent it from erroring on warnings.
       # - name: Validate Compose Files with Defang CLI
       #   run: |
-      #     eval "$(curl -Ls https://s.defang.io/install)"
+      #     eval "$(curl -fsSL https://s.defang.io/install)"
       #     cat modified.txt | xargs -n1 defang compose config -C > /dev/null
 
       - name: Add checklist to PR description

--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Checks
         id: checks
         run: |
-          eval "$(curl -fsSL https://s.defang.io/install)"
+          eval "$(curl -fsSL s.defang.io/install)"
           ./scripts/check-sample-files.sh > checklist.txt
           ./scripts/check-modified-samples.sh > modified.txt
           echo "@@ MODIFIED @@"
@@ -31,7 +31,7 @@ jobs:
       #       once we figure out how to prevent it from erroring on warnings.
       # - name: Validate Compose Files with Defang CLI
       #   run: |
-      #     eval "$(curl -fsSL https://s.defang.io/install)"
+      #     eval "$(curl -fsSL s.defang.io/install)"
       #     cat modified.txt | xargs -n1 defang compose config -C > /dev/null
 
       - name: Add checklist to PR description

--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Checks
         id: checks
         run: |
-          . <(curl -Ls https://s.defang.io/install)
+          eval "$(curl -Ls https://s.defang.io/install)"
           ./scripts/check-sample-files.sh > checklist.txt
           ./scripts/check-modified-samples.sh > modified.txt
           echo "@@ MODIFIED @@"
@@ -31,7 +31,7 @@ jobs:
       #       once we figure out how to prevent it from erroring on warnings.
       # - name: Validate Compose Files with Defang CLI
       #   run: |
-      #     . <(curl -Ls https://s.defang.io/install)
+      #     eval "$(curl -Ls https://s.defang.io/install)"
       #     cat modified.txt | xargs -n1 defang compose config -C > /dev/null
 
       - name: Add checklist to PR description

--- a/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
+++ b/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
@@ -17,7 +17,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-eval "$(curl -fsSL https://s.defang.io/install)"
+eval "$(curl -fsSL s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.

--- a/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
+++ b/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
@@ -17,7 +17,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-eval "$(curl -Ls https://s.defang.io/install)"
+eval "$(curl -fsSL https://s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.

--- a/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
+++ b/samples/nextjs-documentation/app/pages/getting-started/installing.mdx
@@ -17,7 +17,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-. <(curl -Ls https://s.defang.io/install)
+eval "$(curl -Ls https://s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.

--- a/samples/vllm/ui/src/app/docs.md
+++ b/samples/vllm/ui/src/app/docs.md
@@ -107,7 +107,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-. <(curl -Ls https://s.defang.io/install)
+eval "$(curl -Ls https://s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.

--- a/samples/vllm/ui/src/app/docs.md
+++ b/samples/vllm/ui/src/app/docs.md
@@ -107,7 +107,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-eval "$(curl -fsSL https://s.defang.io/install)"
+eval "$(curl -fsSL s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.

--- a/samples/vllm/ui/src/app/docs.md
+++ b/samples/vllm/ui/src/app/docs.md
@@ -107,7 +107,7 @@ brew install defang-io/defang/defang
 You can install the Defang CLI using a bash script. Just run the following command in your terminal:
 
 ```bash
-eval "$(curl -Ls https://s.defang.io/install)"
+eval "$(curl -fsSL https://s.defang.io/install)"
 ```
 
 The script will try to download the appropriate binary for your operating system and architecture, add it to `~/.local/bin`, and add `~/.local/bin` to your `PATH` if it's not already there, with your permission. If you do not provide permission it will print an appropriate instruction for you to follow to add it manually. You can also customize the installation directory by setting the `INSTALL_DIR` environment variable before running the script.


### PR DESCRIPTION
Linked to https://github.com/DefangLabs/defang/pull/866 to reflect its changes.

Uses `eval "$(curl -fsSL s.defang.io/install)"` instead of `. <(curl -Ls https://s.defang.io/install)` due to bugs in defang installation for some older versions of bash.
## Samples Checklist
✅ All good!