### PR TITLE
Make curl use eval consistently

### DIFF
--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Defang
         run: |
-          . <(curl -Ls https://s.defang.io/install)
+          eval "$(curl -fsSL s.defang.io/install)"
 
       - name: Run Checks
         id: checks

--- a/.github/workflows/deploy-changed-samples.yml
+++ b/.github/workflows/deploy-changed-samples.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install Defang
         run: |
-          . <(curl -Ls https://s.defang.io/install)
+          eval "$(curl -fsSL s.defang.io/install)"
 
       - name: Run tests
         id: run-tests


### PR DESCRIPTION
For consistency with #258, changed two more occurrences of `curl` to use `eval "$(curl -fsSL s.defang.io/install)"` instead of `. <(...)` 