### PR TITLE
Minor changes to golang-slackbot readme

### DIFF
--- a/samples/golang-slackbot/README.md
+++ b/samples/golang-slackbot/README.md
@@ -2,7 +2,7 @@
 
 [![1-click-deploy](https://defang.io/deploy-with-defang.png)](https://portal.defang.dev/redirect?url=https%3A%2F%2Fgithub.com%2Fnew%3Ftemplate_name%3Dsample-golang-slackbot-template%26template_owner%3DDefangSamples)
 
-This is a simple slackbot that takes a request and posts the message from the body to a slack channel.
+This is a simple Slackbot that takes a request and posts the message from the body to a Slack channel.
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ If you want to deploy to your own cloud account, you can use Defang BYOC:
 
 Once the Slackbot is deployed, you can send a POST request to the `/` endpoint with a JSON body containing the message you want to post to the Slack channel. Here's an example:
 
-```sh
+```bash
 curl 'https://raphaeltm-bot--8080.prod1.defang.dev/' \
   -H 'content-type: application/json' \
   --data-raw $'{"message":"This is your bot speaking. We\'ll be landing in 10 minutes. Please fasten your seatbelts."}'


### PR DESCRIPTION
- capitalized Slack
- use bash instead of sh in embedded code
## Samples Checklist
✅ All good!