### PR TITLE
remove OPENAI_API_KEY from provider sample

### DIFF
--- a/samples/managed-llm-provider/app/app.py
+++ b/samples/managed-llm-provider/app/app.py
@@ -1,9 +1,10 @@
-import os
 import json
 import logging
+import os
+
+import requests
 from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
-import requests
 
 app = FastAPI()
 
@@ -18,7 +19,7 @@ MODEL_ID = os.getenv("MODEL", "gpt-4-turbo")
 # Get the API key for the LLM
 # For development, you can use your local API key. In production, the LLM gateway service will override the need for it.
 def get_api_key():
-    return os.getenv("OPENAI_API_KEY", "API key not set")
+    return os.getenv("OPENAI_API_KEY", "")
 
 # Home page form
 @app.get("/", response_class=HTMLResponse)
@@ -29,14 +30,14 @@ async def home():
         <body>
             <h1>Ask the AI Model</h1>
             <form method="post" action="/ask" onsubmit="document.getElementById('loader').style.display='block'">
-                <textarea name="prompt" autofocus="autofocus" rows="5" cols="60" placeholder="Enter your question here..." 
+                <textarea name="prompt" autofocus="autofocus" rows="5" cols="60" placeholder="Enter your question here..."
                   onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.form.submit();}">
                 </textarea>
                 <br><br>
                 <input type="submit" value="Ask">
             </form>
         </body>
-        
+
     </html>
     """
 

--- a/samples/managed-llm-provider/compose.yaml
+++ b/samples/managed-llm-provider/compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    build: 
+    build:
       context: ./app
       dockerfile: Dockerfile
     ports:
@@ -9,7 +9,6 @@ services:
     environment:
       - ENDPOINT_URL=http://llm/api/v1/chat/completions   # endpoint to the Provider Service
       - MODEL=anthropic.claude-3-haiku-20240307-v1:0   # LLM model ID used in the Provider Service
-      - OPENAI_API_KEY=FAKE_TOKEN   # the actual value will be ignored when using the Provider Service
     healthcheck:
       test: ["CMD", "python3", "-c", "import sys, urllib.request; urllib.request.urlopen(sys.argv[1]).read()", "http://localhost:8000/"]
       interval: 30s


### PR DESCRIPTION
No auth needed for `provider` pseudo-service.
## Samples Checklist
✅ All good!