### PR TITLE
make sample use "default" model

### DIFF
--- a/samples/managed-llm/compose.yaml
+++ b/samples/managed-llm/compose.yaml
@@ -8,7 +8,7 @@ services:
     restart: always
     environment:
       - ENDPOINT_URL=http://llm/api/v1/chat/completions   # endpoint to the gateway service
-      - MODEL=anthropic.claude-3-haiku-20240307-v1:0  # LLM model ID used for the gateway
+      - MODEL=us.amazon.nova-micro-v1:0  # LLM model ID used for the gateway
       - OPENAI_API_KEY=FAKE_TOKEN   # the actual value will be ignored when using the gateway, but it should match the one in the llm service
     healthcheck:
       test: ["CMD", "python3", "-c", "import sys, urllib.request; urllib.request.urlopen(sys.argv[1]).read()", "http://localhost:8000/"]
@@ -29,8 +29,6 @@ services:
         mode: host
     environment:
       - OPENAI_API_KEY=FAKE_TOKEN # this value must match the one in the app service
-      - USE_MODEL_MAPPING=false
-      - DEBUG=true
       # if using GCP for BYOC deployment, add these environment variables:
       # - GCP_PROJECT_ID=${GCP_PROJECT_ID}
       # - GCP_REGION=${GCP_REGION}

--- a/samples/managed-llm/compose.yaml
+++ b/samples/managed-llm/compose.yaml
@@ -8,7 +8,7 @@ services:
     restart: always
     environment:
       - ENDPOINT_URL=http://llm/api/v1/chat/completions   # endpoint to the gateway service
-      - MODEL=us.amazon.nova-micro-v1:0  # LLM model ID used for the gateway
+      - MODEL=default
       - OPENAI_API_KEY=FAKE_TOKEN   # the actual value will be ignored when using the gateway, but it should match the one in the llm service
     healthcheck:
       test: ["CMD", "python3", "-c", "import sys, urllib.request; urllib.request.urlopen(sys.argv[1]).read()", "http://localhost:8000/"]


### PR DESCRIPTION
Gateway supports a "default" model so use that so that playground users can still be provider agnosttic.
## Samples Checklist
✅ All good!