### PR TITLE
fix  OPENAI_API_KEY between llm and app 

### DIFF
--- a/samples/managed-llm-provider/compose.yaml
+++ b/samples/managed-llm-provider/compose.yaml
@@ -9,6 +9,7 @@ services:
     environment:
       - LLM_URL=http://llm/api/v1/
       - LLM_MODEL=default
+      - OPENAI_API_KEY=TOKEN
       # For other models, see https://docs.defang.io/docs/concepts/managed-llms/openai-access-gateway#model-mapping
     healthcheck:
       test: ["CMD", "python3", "-c", "import sys, urllib.request; urllib.request.urlopen(sys.argv[1]).read()", "http://localhost:8000/"]


### PR DESCRIPTION
Add OPENAI_API_KEY to environment variable in app service of compose yaml. This will fix issue when the value is updated and the project is redeployed but only llm service is updated (as that has a recognizable in the env but the app does not because it did not declare that it was using the env)  resulting in mismatch tokens.
## Samples Checklist
✅ All good!