### PR TITLE
Update golang mongo sample to work with GCP mongo support

### DIFF
--- a/samples/golang-mongodb/app/main.go
+++ b/samples/golang-mongodb/app/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	fmt.Println("Connected to MongoDB!")
 
-	collection := client.Database("taskManager").Collection("tasks")
+	collection := client.Database("taskmanager").Collection("tasks")
 
 	fs := http.FileServer(http.Dir("./static"))
 	http.Handle("/", fs)

--- a/samples/golang-mongodb/compose.yaml
+++ b/samples/golang-mongodb/compose.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       # If you want to use MongoDB Atlas, you can set the URI with `defang config set MONGO_URI`.
       # This will override any value set in the environment variable:
-      - MONGO_URI=mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@db:27017/
+      - MONGO_URI=mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@db:27017/taskmanager
     #deploy:
     #  resources:
     #    reservations:


### PR DESCRIPTION
Changes:
- GCP firestore database name must be all lower case
- GCP mongo support needs database name from the connection string to create database instances