### PR TITLE
unanchor the gateway used

### DIFF
--- a/samples/agentic-strands/app/agent.py
+++ b/samples/agentic-strands/app/agent.py
@@ -159,9 +159,9 @@ def chat():
         return jsonify({"error": str(e), "response": str(e)}), 500
 
 @app.get("/health")
-async def health_check():
+def health_check():
     """Health check endpoint"""
-    return {"status": "healthy", "message": "AI Library Assistant is running"}
+    return "ok"
 
 
 # Start Flask server when this script is run directly

--- a/samples/agentic-strands/app/agent.py
+++ b/samples/agentic-strands/app/agent.py
@@ -158,6 +158,12 @@ def chat():
         print(f"Error in /chat endpoint: {str(e)}")
         return jsonify({"error": str(e), "response": str(e)}), 500
 
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy", "message": "AI Library Assistant is running"}
+
+
 # Start Flask server when this script is run directly
 if __name__ == '__main__':
 

--- a/samples/agentic-strands/compose.yaml
+++ b/samples/agentic-strands/compose.yaml
@@ -19,7 +19,7 @@ services:
           "CMD",
           "python3",
           "-c",
-          "import urllib.request; exit(0) if urllib.request.urlopen('http://localhost:5001/').status == 200 else exit(1)",
+          "import urllib.request; exit(0) if urllib.request.urlopen('http://localhost:5001/health').status == 200 else exit(1)",
         ]
       interval: 30s
       timeout: 5s

--- a/samples/agentic-strands/compose.yaml
+++ b/samples/agentic-strands/compose.yaml
@@ -13,6 +13,18 @@ services:
       LLM_URL: http://llm/api/v1/
       LLM_MODEL: default
       OPENAI_API_KEY: FAKE_TOKEN
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; exit(0) if urllib.request.urlopen('http://localhost:5001/').status == 200 else exit(1)",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       - llm
 

--- a/samples/agentic-strands/compose.yaml
+++ b/samples/agentic-strands/compose.yaml
@@ -19,7 +19,7 @@ services:
   llm:
     environment:
       - OPENAI_API_KEY=FAKE_TOKEN
-    image: defangio/openai-access-gateway:06339c7
+    image: defangio/openai-access-gateway
     ports:
       - target: 80
         published: 80


### PR DESCRIPTION
This sample was anchored to a specific gateway release to overcome cache. Cache is no longer and issue so we will remove the specific version and use the latest.
## Samples Checklist
✅ All good!