### PR TITLE
Surface deployed endpoints on the GitHub run summary

### DIFF
--- a/templates/defang.yaml
+++ b/templates/defang.yaml
@@ -21,7 +21,9 @@ on:
 jobs:
   defang:
     name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'default stack' }}
-    environment: defang-${{ github.event.inputs.stack || 'production' }}
+    environment:
+      name: defang-${{ github.event.inputs.stack || 'production' }}
+      url: ${{ steps.deploy.outputs.endpoint }}
     runs-on: ubuntu-latest
     timeout-minutes: 70
     permissions:
@@ -37,13 +39,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'default stack' }}
+        id: deploy
         uses: DefangLabs/defang-github-action@v2
         with:
           command: ${{ github.event.inputs.action || 'up' }}
           stack: ${{ github.event.inputs.stack || '' }}
-
-      - name: Deployment Summary
-        uses: DefangLabs/defang-github-action@v2
-        with:
-          command: services
-          stack: ${{ github.event.inputs.stack || '' }}
+          summary: ${{ (github.event.inputs.action || 'up') != 'down' }}


### PR DESCRIPTION
## What

Makes the deployed app's endpoints **front and center** on the GitHub Actions run, instead of buried in the collapsed action log.

Two changes to the deploy workflow template:

1. **`environment.url`** — wired to a new `endpoint` output from the Defang action, so GitHub shows a clickable **"View deployment"** link on the run page, the Environments tab, and the repo sidebar.
2. **`summary: true`** — the action writes a `defang services` table (public endpoints as links, internal services as code) to the job **Summary** tab.

The old separate `command: services` step is removed — its output only landed in the collapsed log, and the action now owns this.

## Dependency

Requires the `summary` input and `endpoint` output to land in [`DefangLabs/defang-github-action`](https://github.com/DefangLabs/defang-github-action) (companion PR) and the `v2` tag to move. Until then this **degrades gracefully**: GitHub logs an "unknown input" warning and the environment URL stays blank — nothing breaks.

## Notes

- Almost all the logic lives in the action (generic, reusable by every Defang user). The only sample-specific bits are the `summary:` flag and the `environment.url` wiring — `environment` is a job-level key a composite action can't set.
- `summary` is disabled on `down` teardowns.
- Worth confirming on the first real `workflow_dispatch` run: that `environment.url` correctly resolves `steps.deploy.outputs.endpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)