### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/build-samples-json.yml
+++ b/.github/workflows/build-samples-json.yml
@@ -17,7 +17,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v5
 
   #     - name: Get list of changed files
   #       id: changed
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -74,7 +74,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v5
 
   #     - name: Set up Golang
   #       uses: actions/setup-go@v5

--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Fetch two to see changes in current commit
           fetch-depth: 2

--- a/.github/workflows/deploy-changed-samples.yml
+++ b/.github/workflows/deploy-changed-samples.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-sample-template.yml
+++ b/.github/workflows/publish-sample-template.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history so the push's "before" SHA is reachable for the diff
           # below (a push can add several commits at once).

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/update-template-workflows.yml
+++ b/.github/workflows/update-template-workflows.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/starter-sample/.github/workflows/defang.yaml
+++ b/starter-sample/.github/workflows/defang.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy
         uses: DefangLabs/defang-github-action@v1.3.2


### PR DESCRIPTION
actions/checkout@v4 is a Node 20 action; GitHub Actions is deprecating Node 20 runners (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This bumps to v5, which uses Node 24 and removes the deprecation warning.