### PR TITLE
Skip dependabot-run steps that need Actions secrets

### DIFF
--- a/.github/workflows/check-sample.yml
+++ b/.github/workflows/check-sample.yml
@@ -59,6 +59,12 @@ jobs:
 
       - name: Create / Update Template Repo
         uses: actions/github-script@v7
+        # Dependabot-triggered pull_request runs get no access to Actions secrets
+        # (GitHub restricts this the same way it does for fork PRs), so
+        # TEMPLATES_MANAGER_TOKEN is empty here and this step would always fail.
+        # Skip it so the required check_samples check reports "success" (skipped)
+        # instead of blocking dependabot-automerge on every dependency bump.
+        if: github.actor != 'dependabot[bot]'
         env:
           PUSH_TOKEN: ${{ secrets.TEMPLATES_MANAGER_TOKEN }}
         with:

--- a/.github/workflows/deploy-changed-samples.yml
+++ b/.github/workflows/deploy-changed-samples.yml
@@ -69,7 +69,11 @@ jobs:
       - name: Deploy changed samples to staging
         id: deploy-samples
         shell: bash # implies set -o pipefail, so pipe below will keep the exit code from loadtest
-        if: env.should_continue == 'true'
+        # Dependabot-triggered pull_request runs get no access to Actions secrets
+        # (GitHub restricts this the same way it does for fork PRs), so this step
+        # would always fail here. Skip it so the required check reports "success"
+        # (skipped) instead of blocking dependabot-automerge on every bump.
+        if: env.should_continue == 'true' && github.actor != 'dependabot[bot]'
         env:
           FIXED_VERIFIER_PK: ${{ secrets.FIXED_VERIFIER_PK }}
           TEST_ALLOWED_HOSTS: ${{ secrets.TEST_ALLOWED_HOSTS }}
@@ -134,7 +138,7 @@ jobs:
           ./tools/testing/loadtest -c fabric-staging.defang.dev:443 --timeout=15m --concurrency=10 -s $SAMPLES -o output --markdown=true | tee output/summary.log | grep -v '^\s*[-*]' # removes load sample log lines
       - name: Upload Output as Artifact
         uses: actions/upload-artifact@v4
-        if: env.should_continue == 'true' && (success() || steps.deploy-samples.outcome == 'failure') # Always upload result unless cancelled
+        if: env.should_continue == 'true' && github.actor != 'dependabot[bot]' && (success() || steps.deploy-samples.outcome == 'failure') # Always upload result unless cancelled
         with:
           name: program-output
           path: output/**


### PR DESCRIPTION
## Summary
- Dependabot-triggered `pull_request` runs get **no access to repo Actions secrets** — GitHub applies the same restriction it does for fork PRs, to stop a malicious dependency bump from exfiltrating secrets. `FIXED_VERIFIER_PK`, every `TEST_*` var, and `TEMPLATES_MANAGER_TOKEN` are all empty in that context.
- `deploy_changed_samples` (Deploy Changed Samples) and `check_samples` (Check Samples) are both required status checks, and both fail every single dependabot PR because of this — e.g. runs [33447572730](https://github.com/DefangLabs/samples/actions/runs/33447572730) and [33447572744](https://github.com/DefangLabs/samples/actions/runs/33447572744) from PR #664 today. This has been happening on essentially every dependabot bump since at least July 21, and permanently blocks `dependabot-automerge` (`.github/workflows/dependabot-automerge.yml`) from ever merging anything — it approves and enables auto-merge, but the PR stays `BLOCKED` forever on these two checks.
- This PR skips just the secret-dependent steps (the staging deploy, and the template-repo push) when `github.actor == 'dependabot[bot]'`, so those jobs report success (skipped) instead of failure. Nothing changes for human-authored or other-bot PRs. Dependabot PRs weren't getting real deploy/template coverage from these steps anyway, since the secrets were always empty — this just stops that guaranteed failure from blocking merges.
- I deliberately did **not** switch these workflows to `pull_request_target` to regain secret access — that would run dependency-bump code with full secrets, which is the exact supply-chain risk the current restriction exists to prevent.

## Longer-term option
If real deploy coverage for dependabot bumps is wanted, the supported path is duplicating the needed secrets into the repo's separate **Dependabot secrets** store (Settings → Secrets and variables → Dependabot) — that requires someone with secret-value access, which I don't have. Happy to file that as a follow-up if wanted.

## Test plan
- [ ] Confirm a subsequent dependabot PR shows `deploy_changed_samples` and `check_samples` as passing (skipped) rather than failing
- [ ] Confirm `dependabot-automerge` can then actually merge a patch/minor bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automated template repository updates no longer run for Dependabot-triggered changes.
  - Sample deployments and artifact uploads are skipped for Dependabot-triggered pull requests.
  - Existing deployment and artifact behavior remains unchanged for other eligible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->